### PR TITLE
Adopt time_t for internal timekeeping of libzsf.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,8 @@ set(ZSF_SOURCE_FILES
     src/load_time_averaged.c
     src/sealock.h
     src/sealock.c
+    src/timestamp.h
+    src/timestamp.c
     src/ini/ini_read.h
     src/ini/ini_read.c
     src/zsf_config.h

--- a/src/csv/load_csv.h
+++ b/src/csv/load_csv.h
@@ -2,8 +2,8 @@
 
 #pragma once
 
-#ifndef _CSV_H_
-#  define _CSV_H_
+#ifndef CSV_H
+#  define CSV_H
 
 #  include <stddef.h>
 
@@ -95,4 +95,4 @@ int set_dummy(void *ptr, csv_value_t value);
 }
 #  endif
 
-#endif // _CSV_H_
+#endif // CSV_H

--- a/src/dimr_bmi.c
+++ b/src/dimr_bmi.c
@@ -1,6 +1,8 @@
 
 #include "dimr_bmi.h"
 #include "config.h"
+#include "timestamp.h"
+
 #include <assert.h>
 #include <stdio.h>
 #include <string.h>
@@ -215,6 +217,8 @@ int get_value_ptr(char *key, void **dst_ptr) {
 }
 
 // Exported
+// Update ZSF state.
+// Advances the current time by dt seconds.
 int update(double dt) {
   int status = 0;
   sealock_index_t lock_index = 0;
@@ -222,9 +226,8 @@ int update(double dt) {
 #if ZSF_VERBOSE
   printf("ZSF: %s( %g ) called.\n", __func__, dt);
 #endif
-  config.current_time += dt;
+  config.current_time += (time_t)dt;
 
-  // TODO: Add loop over locks.
   status = sealock_update(&config.locks[lock_index], config.current_time);
 
   return zsf_to_dimr_status(status);
@@ -256,7 +259,7 @@ void get_start_time(double *start_time_ptr) {
 #if ZSF_VERBOSE
   printf("ZSF: %s( %g ) called.\n", __func__, *start_time_ptr);
 #endif
-  // TODO: Implement me
+  *start_time_ptr = time_to_timestamp(config.start_time);
 }
 
 // Exported
@@ -264,7 +267,7 @@ void get_end_time(double *end_time_ptr) {
 #if ZSF_VERBOSE
   printf("ZSF: %s( %g ) called.\n", __func__, *end_time_ptr);
 #endif
-  // TODO: Implement me
+  *end_time_ptr = time_to_timestamp(config.end_time);
 }
 
 // Exported
@@ -280,15 +283,6 @@ void get_current_time(double *current_time_ptr) {
 #if ZSF_VERBOSE
   printf("ZSF: %s( %g ) called.\n", __func__, *current_time_ptr);
 #endif
-  *current_time_ptr = config.current_time;
+  *current_time_ptr = time_to_timestamp(config.current_time);
 }
 
-// Points to a Log object (see log.h in DIMR)
-void set_dimr_logger(void *logptr) {
-  // TODO: Implement me?
-}
-
-// Takes a function pointer (not sure what it is)
-void set_logger_c_callback(void (*callback)(char *msg)) {
-  // TODO: Implement me?
-}

--- a/src/ini/ini_read.h
+++ b/src/ini/ini_read.h
@@ -1,8 +1,8 @@
 
 #pragma once
 
-#ifndef _INI_READ_H
-#  define _INI_READ_H
+#ifndef INI_READ_H
+#  define INI_READ_H
 
 #  define INI_OK (0)    /* okay */
 #  define INI_FAIL (-1) /* failed */
@@ -29,4 +29,4 @@ int ini_read(const char *filepath, ini_callback callback, void *data_ptr);
 }
 #  endif
 
-#endif // _INI_READ_H
+#endif // INI_READ_H

--- a/src/load_time_averaged.h
+++ b/src/load_time_averaged.h
@@ -3,8 +3,8 @@
 
 #include "csv/load_csv.h"
 
-#ifndef _LOAD_TIME_AVERAGED_H_
-#  define _LOAD_TIME_AVERAGED_H_
+#ifndef LOAD_TIME_AVERAGED_H
+#  define LOAD_TIME_AVERAGED_H
 
 #  if defined(__cplusplus)
 extern "C" {
@@ -16,4 +16,4 @@ int load_time_averaged_timeseries(csv_context_t *context, char *filepath);
 }
 #  endif
 
-#endif // _LOAD_TIME_AVERAGED_H_
+#endif // LOAD_TIME_AVERAGED_H

--- a/src/sealock.c
+++ b/src/sealock.c
@@ -36,7 +36,7 @@ int sealock_load_timeseries(sealock_state_t *lock, char *filepath) {
   return SEALOCK_ERROR;
 }
 
-void _sealock_update_current_row(sealock_state_t *lock, time_t time) {
+static void sealock_update_current_row(sealock_state_t *lock, time_t time) {
   size_t row = lock->current_row;
   while (time > lock->times[row] && row < lock->times_len) {
     row++;
@@ -44,15 +44,15 @@ void _sealock_update_current_row(sealock_state_t *lock, time_t time) {
   lock->current_row = row ? row - 1 : 0;
 }
 
-int _sealock_update_cycle_average_parameters(sealock_state_t *lock, time_t time) {
-  _sealock_update_current_row(lock, time);
+static int sealock_update_cycle_average_parameters(sealock_state_t *lock, time_t time) {
+  sealock_update_current_row(lock, time);
   return get_csv_row_data(&lock->timeseries_data, lock->current_row, &lock->parameters) == CSV_OK
              ? SEALOCK_OK
              : SEALOCK_ERROR;
 }
 
-int _sealock_update_phase_wise_parameters(sealock_state_t *lock, time_t time) {
-  _sealock_update_current_row(lock, time);
+static int sealock_update_phase_wise_parameters(sealock_state_t *lock, time_t time) {
+  sealock_update_current_row(lock, time);
   // TODO: implement me: See UNST-7866.
   return SEALOCK_OK;
 }
@@ -62,10 +62,10 @@ int sealock_set_parameters_for_time(sealock_state_t *lock, time_t time) {
 
   switch (lock->computation_mode) {
   case cycle_average_mode:
-    status = _sealock_update_cycle_average_parameters(lock, time);
+    status = sealock_update_cycle_average_parameters(lock, time);
     break;
   case phase_wise_mode:
-    status = _sealock_update_phase_wise_parameters(lock, time);
+    status = sealock_update_phase_wise_parameters(lock, time);
     break;
   default:
     status = SEALOCK_ERROR; // Should never happen.

--- a/src/sealock.c
+++ b/src/sealock.c
@@ -1,30 +1,42 @@
 
-#include <stdlib.h>
 
-#include "load_time_averaged.h"
 #include "sealock.h"
+#include "load_time_averaged.h"
+#include "timestamp.h"
+
+#include <stdlib.h>
 
 int sealock_load_timeseries(sealock_state_t *lock, char *filepath) {
   int status = SEALOCK_OK;
+  double *time_column = NULL;
+  size_t num_rows = 0;
+
   // read csv data
   if (!load_time_averaged_timeseries(&lock->timeseries_data, filepath)) {
     lock->current_row = 0;
-    lock->times_len = get_csv_num_rows(&lock->timeseries_data);
-    if (lock->times_len == 0) {
+    num_rows = get_csv_num_rows(&lock->timeseries_data);
+    if (!num_rows)
       return SEALOCK_ERROR;
-    }
-    lock->times = malloc(lock->times_len * sizeof(double));
-    if (lock->times != NULL) {
-      return get_csv_column_data(&lock->timeseries_data, "time", lock->times, lock->times_len);
-    } else {
-      lock->times_len = 0;
-      return SEALOCK_ERROR;
+    time_column = malloc(num_rows * sizeof(double));
+    if (time_column != NULL) {
+      status = get_csv_column_data(&lock->timeseries_data, "time", time_column, num_rows);
+      if (status == SEALOCK_OK) {
+        lock->times = timestamp_array_to_times(time_column, num_rows);
+        if (lock->times) {
+          lock->times_len = num_rows;
+        } else {
+          status = SEALOCK_ERROR;
+        }
+      }
+      free(time_column);
+      return status;
     }
   }
+
   return SEALOCK_ERROR;
 }
 
-void _sealock_update_current_row(sealock_state_t *lock, double time) {
+void _sealock_update_current_row(sealock_state_t *lock, time_t time) {
   size_t row = lock->current_row;
   while (time > lock->times[row] && row < lock->times_len) {
     row++;
@@ -32,20 +44,20 @@ void _sealock_update_current_row(sealock_state_t *lock, double time) {
   lock->current_row = row ? row - 1 : 0;
 }
 
-int _sealock_update_cycle_average_parameters(sealock_state_t *lock, double time) {
+int _sealock_update_cycle_average_parameters(sealock_state_t *lock, time_t time) {
   _sealock_update_current_row(lock, time);
   return get_csv_row_data(&lock->timeseries_data, lock->current_row, &lock->parameters) == CSV_OK
              ? SEALOCK_OK
              : SEALOCK_ERROR;
 }
 
-int _sealock_update_phase_wise_parameters(sealock_state_t *lock, double time) {
+int _sealock_update_phase_wise_parameters(sealock_state_t *lock, time_t time) {
   _sealock_update_current_row(lock, time);
   // TODO: implement me: See UNST-7866.
   return SEALOCK_OK;
 }
 
-int sealock_set_parameters_for_time(sealock_state_t *lock, double time) {
+int sealock_set_parameters_for_time(sealock_state_t *lock, time_t time) {
   int status = SEALOCK_OK;
 
   switch (lock->computation_mode) {
@@ -62,7 +74,7 @@ int sealock_set_parameters_for_time(sealock_state_t *lock, double time) {
   return status;
 }
 
-int sealock_update(sealock_state_t *lock, double time) {
+int sealock_update(sealock_state_t *lock, time_t time) {
   int status = sealock_set_parameters_for_time(lock, time);
   if (status == SEALOCK_OK) {
     switch (lock->computation_mode) {

--- a/src/sealock.h
+++ b/src/sealock.h
@@ -1,7 +1,7 @@
 
 
-#ifndef _SEALOCK_H_
-#define _SEALOCK_H_
+#ifndef SEALOCK_H
+#define SEALOCK_H
 
 #include "csv/load_csv.h"
 #include "zsf.h"
@@ -42,4 +42,4 @@ int sealock_update(sealock_state_t *lock, time_t time);
 }
 #endif
 
-#endif // _SEALOCK_H_
+#endif // SEALOCK_H

--- a/src/sealock.h
+++ b/src/sealock.h
@@ -5,6 +5,7 @@
 
 #include "csv/load_csv.h"
 #include "zsf.h"
+#include <time.h>
 
 #define SEALOCK_OK (0)
 #define SEALOCK_ERROR (-1)
@@ -29,13 +30,13 @@ typedef struct sealock_state_struct {
   char *operational_parameters_file;
   csv_context_t timeseries_data;
   size_t current_row;
-  double *times;
+  time_t *times;
   size_t times_len;
 } sealock_state_t;
 
 int sealock_load_timeseries(sealock_state_t *lock, char *filepath);
-int sealock_set_parameters_for_time(sealock_state_t *lock, double time);
-int sealock_update(sealock_state_t *lock, double time);
+int sealock_set_parameters_for_time(sealock_state_t *lock, time_t time);
+int sealock_update(sealock_state_t *lock, time_t time);
 
 #if defined(__cplusplus)
 }

--- a/src/timestamp.c
+++ b/src/timestamp.c
@@ -8,20 +8,20 @@
 // Convert 'double' timestamp to time_t.
 // Returns -1 on error.
 time_t timestamp_to_time(double timestamp) {
-  long long cts = timestamp;
-  struct tm ts;
+  long long converted_ts = timestamp;
+  struct tm date_time;
 
-  ts.tm_sec = 0;
-  ts.tm_min = cts % 100;
-  ts.tm_hour = (cts / 100) % 100;
-  ts.tm_mday = (cts / 10000) % 100;
-  ts.tm_mon = (cts / 1000000) % 100 - 1;
-  ts.tm_year = (cts / 100000000) - 1900;
-  ts.tm_wday = 0;
-  ts.tm_yday = 0;
-  ts.tm_isdst = -1;
+  date_time.tm_sec = 0;
+  date_time.tm_min = converted_ts % 100;
+  date_time.tm_hour = (converted_ts / 100) % 100;
+  date_time.tm_mday = (converted_ts / 10000) % 100;
+  date_time.tm_mon = (converted_ts / 1000000) % 100 - 1;
+  date_time.tm_year = (converted_ts / 100000000) - 1900;
+  date_time.tm_wday = 0;
+  date_time.tm_yday = 0;
+  date_time.tm_isdst = -1;
 
-  return mktime(&ts);
+  return mktime(&date_time);
 }
 
 // Duplicate and convert timestamp double array to a time_t array.
@@ -30,7 +30,7 @@ time_t *timestamp_array_to_times(double *timestamps, size_t length) {
   time_t *times = NULL;
 
   if (length) {
-    times = (time_t *)malloc(sizeof(time_t) * length);
+    times = malloc(sizeof(time_t) * length);
     if (times) {
       for (size_t i = 0; i < length; i++) {
         times[i] = timestamp_to_time(timestamps[i]);
@@ -44,18 +44,19 @@ time_t *timestamp_array_to_times(double *timestamps, size_t length) {
 // Convert time_t time to timstamp.
 // Returns -1.0 on error.
 double time_to_timestamp(time_t t) {
-  double dts = -1.0;
-  struct tm *ts;
+  double timestamp = -1.0;
+  struct tm *date_time;
 
   if (t >= 0) {
-    ts = localtime(&t);
-    dts = (ts->tm_year + 1900.0) * 100000000.0;
-    dts += (ts->tm_mon + 1.0) * 1000000.0;
-    dts += ts->tm_hour * 100.0;
-    dts += ts->tm_min;
+    date_time = localtime(&t);
+    timestamp = (date_time->tm_year + 1900.0) * 100000000.0;
+    timestamp += (date_time->tm_mon + 1.0) * 1000000.0;
+    timestamp += date_time->tm_mday * 10000.0;
+    timestamp += date_time->tm_hour * 100.0;
+    timestamp += date_time->tm_min;
   }
 
-  return dts;
+  return timestamp;
 }
 
 // Convert timestamp 'YYYYMMDDhhmm' string format to time_t.

--- a/src/timestamp.c
+++ b/src/timestamp.c
@@ -5,6 +5,8 @@
 #include <errno.h>
 #include <stdlib.h>
 
+// Convert 'double' timestamp to time_t.
+// Returns -1 on error.
 time_t timestamp_to_time(double timestamp) {
   long long cts = timestamp;
   struct tm ts;
@@ -39,19 +41,25 @@ time_t *timestamp_array_to_times(double *timestamps, size_t length) {
   return times;
 }
 
+// Convert time_t time to timstamp.
+// Returns -1.0 on error.
 double time_to_timestamp(time_t t) {
-  double dts = 0.0;
+  double dts = -1.0;
   struct tm *ts;
-  ts = localtime(&t);
 
-  dts = (ts->tm_year + 1900.0) * 100000000.0;
-  dts += (ts->tm_mon + 1.0) * 1000000.0;
-  dts += ts->tm_hour * 100.0;
-  dts += ts->tm_min;
+  if (t >= 0) {
+    ts = localtime(&t);
+    dts = (ts->tm_year + 1900.0) * 100000000.0;
+    dts += (ts->tm_mon + 1.0) * 1000000.0;
+    dts += ts->tm_hour * 100.0;
+    dts += ts->tm_min;
+  }
 
   return dts;
 }
 
+// Convert timestamp 'YYYYMMDDhhmm' string format to time_t.
+// Returns -1 on error.
 time_t timestamp_string_to_time(const char *str, char **end_ptr) {
   double timestamp = strtod(str, end_ptr);
 
@@ -59,5 +67,5 @@ time_t timestamp_string_to_time(const char *str, char **end_ptr) {
     return timestamp_to_time(timestamp);
   }
 
-  return 0;
+  return -1;
 }

--- a/src/timestamp.c
+++ b/src/timestamp.c
@@ -1,0 +1,63 @@
+
+
+#include "timestamp.h"
+
+#include <errno.h>
+#include <stdlib.h>
+
+time_t timestamp_to_time(double timestamp) {
+  long long cts = timestamp;
+  struct tm ts;
+
+  ts.tm_sec = 0;
+  ts.tm_min = cts % 100;
+  ts.tm_hour = (cts / 100) % 100;
+  ts.tm_mday = (cts / 10000) % 100;
+  ts.tm_mon = (cts / 1000000) % 100 - 1;
+  ts.tm_year = (cts / 100000000) - 1900;
+  ts.tm_wday = 0;
+  ts.tm_yday = 0;
+  ts.tm_isdst = -1;
+
+  return mktime(&ts);
+}
+
+// Duplicate and convert timestamp double array to a time_t array.
+// Note: The caller is responsible for deallocating the time_t array.
+time_t *timestamp_array_to_times(double *timestamps, size_t length) {
+  time_t *times = NULL;
+
+  if (length) {
+    times = (time_t *)malloc(sizeof(time_t) * length);
+    if (times) {
+      for (size_t i = 0; i < length; i++) {
+        times[i] = timestamp_to_time(timestamps[i]);
+      }
+    }
+  }
+
+  return times;
+}
+
+double time_to_timestamp(time_t t) {
+  double dts = 0.0;
+  struct tm *ts;
+  ts = localtime(&t);
+
+  dts = (ts->tm_year + 1900.0) * 100000000.0;
+  dts += (ts->tm_mon + 1.0) * 1000000.0;
+  dts += ts->tm_hour * 100.0;
+  dts += ts->tm_min;
+
+  return dts;
+}
+
+time_t timestamp_string_to_time(const char *str, char **end_ptr) {
+  double timestamp = strtod(str, end_ptr);
+
+  if (!errno && ((end_ptr && *end_ptr != str) || !end_ptr)) {
+    return timestamp_to_time(timestamp);
+  }
+
+  return 0;
+}

--- a/src/timestamp.h
+++ b/src/timestamp.h
@@ -1,6 +1,6 @@
 
-#ifndef _TIMESTAMP_H_
-#define _TIMESTAMP_H_
+#ifndef TIMESTAMP_H
+#define TIMESTAMP_H
 
 #include <time.h>
 
@@ -17,4 +17,4 @@ time_t timestamp_string_to_time(const char *str, char **end_ptr);
 }
 #endif
 
-#endif // _TIMESTAMP_H_
+#endif // TIMESTAMP_H

--- a/src/timestamp.h
+++ b/src/timestamp.h
@@ -1,0 +1,20 @@
+
+#ifndef _TIMESTAMP_H_
+#define _TIMESTAMP_H_
+
+#include <time.h>
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+time_t timestamp_to_time(double timestamp);
+time_t *timestamp_array_to_times(double *timestamps, size_t length);
+double time_to_timestamp(time_t t);
+time_t timestamp_string_to_time(const char *str, char **end_ptr);
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif // _TIMESTAMP_H_

--- a/src/zsf_config.c
+++ b/src/zsf_config.c
@@ -2,6 +2,7 @@
 #include "zsf_config.h"
 #include "csv/load_csv.h"
 #include "ini/ini_read.h"
+#include "timestamp.h"
 
 #include <assert.h>
 #include <errno.h>
@@ -50,7 +51,10 @@ int _zsf_ini_handler(char *section, char *key, char *value, void *data_ptr) {
     }
   } else if (!strcmp(section, "general") || !*section) {
     if (!strcmp(key, "start_time")) {
-      config_ptr->current_time = strtod(value, &end_ptr);
+      config_ptr->start_time = timestamp_string_to_time(value, &end_ptr);
+      config_ptr->current_time = config_ptr->start_time;
+    } else if (!strcmp(key, "end_time")) {
+      config_ptr->end_time = timestamp_string_to_time(value, &end_ptr);
     }
   }
 

--- a/src/zsf_config.h
+++ b/src/zsf_config.h
@@ -1,8 +1,8 @@
 
 #pragma once
 
-#ifndef _ZSF_CONFIG_H
-#  define _ZSF_CONFIG_H
+#ifndef ZSF_CONFIG_H
+#  define ZSF_CONFIG_H
 
 #  ifdef __cplusplus
 extern "C" {
@@ -27,4 +27,4 @@ void zsf_config_unload(zsf_config_t *config_ptr);
 }
 #  endif
 
-#endif
+#endif // ZSF_CONFIG_H

--- a/src/zsf_config.h
+++ b/src/zsf_config.h
@@ -15,9 +15,9 @@ extern "C" {
 typedef struct zsf_config_struct {
   sealock_state_t locks[ZSF_MAX_LOCKS];
   unsigned int num_locks;
-  double start_time;
-  double current_time;
-  double end_time;
+  time_t start_time;
+  time_t current_time;
+  time_t end_time;
 } zsf_config_t;
 
 int zsf_config_load(zsf_config_t *config_ptr, const char *filepath);

--- a/src/zsf_config.h
+++ b/src/zsf_config.h
@@ -1,8 +1,6 @@
 
-#pragma once
-
-#ifndef ZSF_CONFIG_H
-#  define ZSF_CONFIG_H
+#ifndef ZSF_CONFIG_H_
+#  define ZSF_CONFIG_H_
 
 #  ifdef __cplusplus
 extern "C" {
@@ -27,4 +25,4 @@ void zsf_config_unload(zsf_config_t *config_ptr);
 }
 #  endif
 
-#endif // ZSF_CONFIG_H
+#endif // ZSF_CONFIG_H_


### PR DESCRIPTION
D-Flow FM often communicates and reads times as timestamps `YYYMMDDhhmm` stored in a double precision float.
To ease time comparisons and adding `dt` seconds to the current time etc,, we replaced all `double` typed timestamps with `time_t` as well as provided some conversion functions in `timestamp.[ch]`.