### PR TITLE
23 support specification of custom vertical flow profiles in ini file

### DIFF
--- a/src/ini/ini_read.c
+++ b/src/ini/ini_read.c
@@ -3,8 +3,9 @@
 
 #include <assert.h>
 #include <ctype.h>
-#include <stddef.h>
+#include <errno.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 #define INI_SECTION_LEN (200)
@@ -18,31 +19,36 @@ static const char ini_section_end_char = ']';
 static const char ini_equal_char1 = '=';
 static const char ini_equal_char2 = ':';
 
-static inline int _at_eol(const char *p) { return (*p == '\n'); }
-static inline int _at_remark(const char *p) { return (*p == ini_rem_char1 || *p == ini_rem_char2); }
-static inline int _at_equals(const char *p) {
+static inline int at_eol(const char *p) { return (*p == '\n'); }
+static inline int at_remark(const char *p) { return (*p == ini_rem_char1 || *p == ini_rem_char2); }
+static inline int at_equals(const char *p) {
   return (*p == ini_equal_char1 || *p == ini_equal_char2);
 }
-static inline int _at_section_start(const char *p) { return (*p == ini_section_start_char); }
-static inline int _at_section_end(const char *p) { return (*p == ini_section_end_char); }
+static inline int at_section_start(const char *p) { return (*p == ini_section_start_char); }
+static inline int at_section_end(const char *p) { return (*p == ini_section_end_char); }
 
-char *_skip_space(char *ptr) {
-  while (ptr && *ptr && isspace(*ptr) && !_at_eol(ptr)) {
+static char *skip_space(const char *ptr) {
+  while (ptr && *ptr && isspace(*ptr) && !at_eol(ptr)) {
     ptr++;
   }
   return ptr;
 }
 
-int _parse_section_header(char **parse_pos_ptr, char *section) {
+static int end_ptr_at_end(const char *end_ptr) {
+  char *real_end = skip_space(end_ptr);
+  return real_end && !*real_end;
+}
+
+static int parse_section_header(char **parse_pos_ptr, char *section) {
   int i = 0;
   char *parse_pos = *parse_pos_ptr;
   parse_pos++; // Skip '['
-  while (*parse_pos && !_at_section_end(parse_pos) && i < INI_SECTION_LEN) {
+  while (*parse_pos && !at_section_end(parse_pos) && i < INI_SECTION_LEN) {
     section[i++] = *parse_pos;
     parse_pos++;
   }
   section[i] = '\0';
-  if (!_at_section_end(parse_pos)) {
+  if (!at_section_end(parse_pos)) {
     return INI_FAIL;
   }
   parse_pos++; // Skip ']'
@@ -50,10 +56,10 @@ int _parse_section_header(char **parse_pos_ptr, char *section) {
   return INI_OK;
 }
 
-int _parse_key(char **parse_pos_ptr, char *key_str) {
+static int parse_key(char **parse_pos_ptr, char *key_str) {
   int i = 0;
   char *parse_pos = *parse_pos_ptr;
-  while (*parse_pos && !_at_equals(parse_pos) && i < INI_LINE_LEN) {
+  while (*parse_pos && !at_equals(parse_pos) && i < INI_LINE_LEN) {
     key_str[i++] = *parse_pos;
     parse_pos++;
   }
@@ -61,14 +67,14 @@ int _parse_key(char **parse_pos_ptr, char *key_str) {
     i--;
   }
   key_str[i] = '\0';
-  if (!_at_equals(parse_pos)) {
+  if (!at_equals(parse_pos)) {
     return INI_FAIL;
   }
   *parse_pos_ptr = parse_pos;
   return INI_OK;
 }
 
-int _parse_value(char **parse_pos_ptr, char *value_str) {
+static int parse_value(char **parse_pos_ptr, char *value_str) {
   int i = 0;
   char *parse_pos = *parse_pos_ptr;
   if (*parse_pos == ini_string_delim) {
@@ -82,7 +88,7 @@ int _parse_value(char **parse_pos_ptr, char *value_str) {
     }
     parse_pos++; // Skip '"'
   } else {
-    while (*parse_pos && !_at_remark(parse_pos) && !_at_eol(parse_pos)) {
+    while (*parse_pos && !at_remark(parse_pos) && !at_eol(parse_pos)) {
       value_str[i++] = *parse_pos;
       parse_pos++;
     }
@@ -124,30 +130,30 @@ int ini_read(const char *filepath, ini_callback callback, void *data_ptr) {
     }
 
     line_no++;
-    parse_pos = _skip_space(parse_pos);
-    if (_at_section_start(parse_pos)) {
-      if (_parse_section_header(&parse_pos, section) != INI_OK) {
+    parse_pos = skip_space(parse_pos);
+    if (at_section_start(parse_pos)) {
+      if (parse_section_header(&parse_pos, section) != INI_OK) {
         error_code = line_no;
         break;
       }
-      // Call callback with empty key to signal new section block.
+      // Call callback with empty key and value to signal new section block.
       if (callback(section, "", "", data_ptr) != INI_OK) {
         error_code = line_no;
         break;
       }
     } else if (isalpha(*parse_pos)) {
-      if (_parse_key(&parse_pos, key_str) != INI_OK) {
+      if (parse_key(&parse_pos, key_str) != INI_OK) {
         error_code = line_no;
         break;
       }
-      parse_pos = _skip_space(parse_pos);
-      if (!_at_equals(parse_pos)) {
+      parse_pos = skip_space(parse_pos);
+      if (!at_equals(parse_pos)) {
         error_code = line_no;
         break;
       }
       parse_pos++;
-      parse_pos = _skip_space(parse_pos);
-      if (_parse_value(&parse_pos, value_str) != INI_OK) {
+      parse_pos = skip_space(parse_pos);
+      if (parse_value(&parse_pos, value_str) != INI_OK) {
         error_code = line_no;
         break;
       }
@@ -160,8 +166,8 @@ int ini_read(const char *filepath, ini_callback callback, void *data_ptr) {
       }
     }
 
-    parse_pos = _skip_space(parse_pos);
-    if (*parse_pos && !(_at_remark(parse_pos) || _at_eol(parse_pos))) {
+    parse_pos = skip_space(parse_pos);
+    if (*parse_pos && !(at_remark(parse_pos) || at_eol(parse_pos))) {
       error_code = line_no;
       break;
     }
@@ -169,4 +175,91 @@ int ini_read(const char *filepath, ini_callback callback, void *data_ptr) {
 
   fclose(file_ptr);
   return error_code;
+}
+
+// Helper functions:
+int ini_parse_int(const char *value, int *status_ptr) {
+  int result = 0;
+  char *end_ptr = NULL;
+
+  assert(value);
+
+  errno = 0;
+  result = strtol(value, &end_ptr, 0);
+  if (status_ptr) {
+    if (errno || end_ptr == value || !end_ptr_at_end(end_ptr)) {
+      *status_ptr = INI_FAIL;
+    } else {
+      *status_ptr = INI_OK;
+    }
+  }
+
+  return result;
+}
+
+double ini_parse_double(const char *value, int *status_ptr) {
+  double result = 0.0;
+  char *end_ptr = NULL;
+
+  assert(value);
+
+  errno = 0;
+  result = strtod(value, &end_ptr);
+  if (status_ptr) {
+    if (errno || end_ptr == value || !end_ptr_at_end(end_ptr)) {
+      *status_ptr = INI_FAIL;
+    } else {
+      *status_ptr = INI_OK;
+    }
+  }
+
+  return result;
+}
+
+double *ini_parse_double_list(const char *value, int *length_ptr, int *status_ptr) {
+  int result_length = 0;
+  double *result_array = NULL;
+  char *tempstr = strdup(value);
+  char *token = NULL;
+  int status = INI_OK;
+
+  assert(value);
+  assert(length_ptr);
+  assert(tempstr);
+
+  // Count number of tokens.
+  token = strtok(tempstr, ",");
+  while (token) {
+    result_length++;
+    token = strtok(NULL, ",");
+  }
+
+  // Restore orignal value
+  strcpy(tempstr, value);
+
+  // Collect values into array
+  result_array = result_length ? calloc(result_length, sizeof(double)) : NULL;
+  if (result_array) {
+    token = strtok(tempstr, ",");
+    for (int i = 0; i < result_length && token && status == INI_OK; i++) {
+      result_array[i] = ini_parse_double(token, &status);
+      token = strtok(NULL, ",");
+    }
+  } else {
+    status = INI_FAIL;
+  }
+  free(tempstr);
+
+  if (status == INI_FAIL) {
+    free(result_array);
+    result_array = NULL;
+  } else {
+    *length_ptr = result_length;
+  }
+
+  if (status_ptr) {
+    *status_ptr = status;
+  }
+
+  return result_array;
 }

--- a/src/ini/ini_read.h
+++ b/src/ini/ini_read.h
@@ -29,6 +29,17 @@ typedef int (*ini_callback)(char *section, char *key, char *value, void *data_pt
  */
 int ini_read(const char *filepath, ini_callback callback, void *data_ptr);
 
+/* Helper functions for handling values within the callback function.
+ * Returns: converted value, success INI_OK was written to the supplied
+ *          status pointer. On failure, INI_FAIL was written instead and
+ *          the return value should be zero or NULL, but don't rely on it.
+ * NOTE: The caller is responsible for deallocating the array returned from
+ *       ini_parse_double_list.
+ */
+int ini_parse_int(const char *value, int *status_ptr);
+double ini_parse_double(const char *value, int *status_ptr);
+double *ini_parse_double_list(const char *value, int *length_ptr, int *status_ptr);
+
 #  ifdef __cplusplus
 }
 #  endif

--- a/src/sealock.h
+++ b/src/sealock.h
@@ -33,6 +33,10 @@ typedef struct sealock_state_struct {
   size_t current_row;
   time_t *times;
   size_t times_len;
+  struct {
+    int length;
+    double *values;
+  } flow_profile;
 } sealock_state_t;
 
 int sealock_load_timeseries(sealock_state_t *lock, char *filepath);

--- a/src/zsf_config.c
+++ b/src/zsf_config.c
@@ -9,7 +9,40 @@
 #include <stdlib.h>
 #include <string.h>
 
-int _zsf_ini_handler(char *section, char *key, char *value, void *data_ptr) {
+// Parse a comma separated list of doubles in value string.
+// Returns number of elements found in the list or 0 on error.
+// If array_ptr is not NULL, the array will be filled with converted double values.
+// NOTE: The caller is responsible for deallocating the array.
+static int parse_double_list(char* value, double** array_ptr) {
+  int num_items = 0;
+  double *array = NULL;
+  char *tempstr = strdup(value);
+  char *token;
+
+  token = strtok(tempstr, ",");
+  while (token) {
+    num_items++;
+    token = strtok(NULL, ",");
+  }
+  free(tempstr);
+
+  if (num_items && array_ptr != NULL) {
+    array = malloc(num_items * sizeof(double));
+    if (array) {
+      token = strtok(value, ",");
+      for (int i = 0; i < num_items && token; i++) {
+        array[i] = strtod(token, NULL);
+        token = strtok(NULL, ",");
+      }
+    }
+    *array_ptr = array;
+  }
+
+  return num_items;
+}
+
+
+static int zsf_ini_handler(char *section, char *key, char *value, void *data_ptr) {
   zsf_config_t *config_ptr = (zsf_config_t *)data_ptr;
   char *end_ptr = NULL;
 
@@ -56,6 +89,16 @@ int _zsf_ini_handler(char *section, char *key, char *value, void *data_ptr) {
       config_ptr->locks[lock_index].parameters.lock_width = strtod(value, &end_ptr);
     } else if (!strcmp(key, "lock_bottom")) {
       config_ptr->locks[lock_index].parameters.lock_bottom = strtod(value, &end_ptr);
+    } else if (!strcmp(key, "flow_profile")) {
+      int length = 0;
+      double *values = NULL;
+      length = parse_double_list(value, &values);
+      if (length) {
+        config_ptr->locks[lock_index].flow_profile.length = length;
+        config_ptr->locks[lock_index].flow_profile.values = values;
+      } else {
+        return INI_FAIL;
+      }
     }
   } else if (!strcmp(section, "general") || !*section) {
     if (!strcmp(key, "start_time")) {
@@ -80,7 +123,7 @@ int zsf_config_load(zsf_config_t *config_ptr, const char *filepath) {
   config_ptr->start_time = 0.0;
   config_ptr->end_time = 0.0;
   config_ptr->current_time = 0.0;
-  return ini_read(filepath, _zsf_ini_handler, config_ptr);
+  return ini_read(filepath, zsf_ini_handler, config_ptr);
 }
 
 void zsf_config_unload(zsf_config_t *config_ptr) {

--- a/src/zsf_config.c
+++ b/src/zsf_config.c
@@ -58,7 +58,7 @@ static int zsf_ini_handler(char *section, char *key, char *value, void *data_ptr
     } else if (!strcmp(key, "flow_profile")) {
       int array_length = 0;
       double *value_array = ini_parse_double_list(value, &array_length, &status);
-      if (array_length && value_array && status == INI_OK) {
+      if (status == INI_OK) {
         config_ptr->locks[lock_index].flow_profile.length = array_length;
         config_ptr->locks[lock_index].flow_profile.values = value_array;
       } else {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -21,3 +21,7 @@ add_test(NAME test_io_layer_distribution COMMAND test_io_layer_distribution)
 add_executable(test_load_csv test_load_csv.c)
 target_link_libraries(test_load_csv PRIVATE test_dependencies)
 add_test(NAME test_load_csv COMMAND test_load_csv WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_executable(test_ini_read test_ini_read.c)
+target_link_libraries(test_ini_read PRIVATE test_dependencies)
+add_test(NAME test_ini_read COMMAND test_ini_read WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})

--- a/tests/test_ini_input.ini
+++ b/tests/test_ini_input.ini
@@ -1,0 +1,19 @@
+# comments can be started by a hash. (For *nix compatibility)
+
+[section1]
+number=1
+another= 3.14
+x_also =5
+y_and_then = 72
+key = value  ; Comments can also be started by semi-colons.
+keyname = value with spaces
+variable = a value ; living on the edge
+var2 = "value with ; included" ; not included
+
+[sections can have spaces]
+novaluegiven =
+novalue_only_comment =  ; no value
+    lots_of_spaces    =      234.5
+attribute : 42
+#disabled = yes
+;disabled = also

--- a/tests/test_ini_input.ini
+++ b/tests/test_ini_input.ini
@@ -15,5 +15,6 @@ novaluegiven =
 novalue_only_comment =  ; no value
     lots_of_spaces    =      234.5
 attribute : 42
+list_variable = 1, 1, 2, 3, 5, 8
 #disabled = yes
 ;disabled = also

--- a/tests/test_ini_read.c
+++ b/tests/test_ini_read.c
@@ -64,10 +64,44 @@ static void test_ini_read() {
   TEST_ASSERT_MESSAGE(status == INI_OK, "Failed to load INI file.");
 }
 
+static void test_ini_parse_int() {
+  int status = INI_OK;
+  int ival = 0;
+
+  ival = ini_parse_int("42", &status);
+  TEST_ASSERT_MESSAGE(status == INI_OK, "Conversion to int failed.");
+  TEST_ASSERT_INT_WITHIN(0, 42, ival);
+}
+
+static void test_ini_parse_double() {
+  int status = INI_OK;
+  double dval = 0.0;
+
+  dval = ini_parse_double("123.4", &status);
+  TEST_ASSERT_MESSAGE(status == INI_OK, "Conversion to double failed.");
+  TEST_ASSERT_DOUBLE_WITHIN(0.05, 123.4, dval);
+
+  dval = ini_parse_double("-567.8", &status);
+  TEST_ASSERT_MESSAGE(status == INI_OK, "Conversion to double failed.");
+  TEST_ASSERT_DOUBLE_WITHIN(0.05, -567.8, dval);
+}
+
+static void test_ini_parse_double_list() {
+  int status = INI_OK;
+  int length = 0;
+  double *array = ini_parse_double_list("1,1,2,3.8, 5 ,8", &length, &status);
+  TEST_ASSERT_MESSAGE(status == INI_OK, "Conversion to double list failed.");
+  TEST_ASSERT(array != NULL);
+  TEST_ASSERT(length == 6);
+}
+
 int main(void) {
   UNITY_BEGIN();
 
   RUN_TEST(test_ini_read);
+  RUN_TEST(test_ini_parse_int);
+  RUN_TEST(test_ini_parse_double);
+  RUN_TEST(test_ini_parse_double_list);
 
   return UNITY_END();
 }

--- a/tests/test_ini_read.c
+++ b/tests/test_ini_read.c
@@ -9,7 +9,50 @@ void setUp(void) {}
 void tearDown(void) {}
 
 static int my_ini_handler(char *section, char *key, char *value, void *data_ptr) {
-  //TODO: Add some asserts here.
+  if (!strcmp(section, "section1")) {
+    if (!strcmp(key, "number")) {
+      TEST_ASSERT_EQUAL_STRING("1", value);
+    } else if (!strcmp(key, "another")) {
+      TEST_ASSERT_EQUAL_STRING("3.14", value);
+    } else if (!strcmp(key, "x_also")) {
+      TEST_ASSERT_EQUAL_STRING("5", value);
+    } else if (!strcmp(key, "y_and_then")) {
+      TEST_ASSERT_EQUAL_STRING("72", value);
+    } else if (!strcmp(key, "key")) {
+      TEST_ASSERT_EQUAL_STRING("value", value);
+    } else if (!strcmp(key, "keyname")) {
+      TEST_ASSERT_EQUAL_STRING("value with spaces", value);
+    } else if (!strcmp(key, "variable")) {
+      TEST_ASSERT_EQUAL_STRING("a value", value);
+    } else if (!strcmp(key, "var2")) {
+      TEST_ASSERT_EQUAL_STRING("value with ; included", value);
+    } else {
+      // Section start, key and value should be empty.
+      TEST_ASSERT_EQUAL_STRING("", key);
+      TEST_ASSERT_EQUAL_STRING("", value);
+    }
+  } else if (!strcmp(section, "sections can have spaces")) {
+    if (!strcmp(key, "novaluegiven")) {
+      TEST_FAIL_MESSAGE("Handler called for key with empty value.");
+    } else if (!strcmp(key, "no_value_only_comment")) {
+      TEST_ASSERT_EQUAL_STRING_MESSAGE("", value, "Comment passed as value.");
+      TEST_FAIL_MESSAGE("Handler called for key with empty value.");
+    } else if (!strcmp(key, "lots_of_spaces")) {
+      TEST_ASSERT_EQUAL_STRING("234.5", value);
+    } else if (!strcmp(key, "attribute")) {
+      TEST_ASSERT_EQUAL_STRING("42", value);
+    } else if (!strcmp(key, "#disabled")) {
+      TEST_FAIL_MESSAGE("Trying to set disabled key.");
+    } else if (!strcmp(key, ";disabled")) {
+      TEST_FAIL_MESSAGE("Trying to set disabled key.");
+    } else {
+      // Section start, key and value should be empty.
+      TEST_ASSERT_EQUAL_STRING("", key);
+      TEST_ASSERT_EQUAL_STRING("", value);
+    }
+  } else {
+    TEST_FAIL_MESSAGE("Unexpected call of handler.");
+  }
   return INI_OK;
 }
 

--- a/tests/test_ini_read.c
+++ b/tests/test_ini_read.c
@@ -1,0 +1,28 @@
+
+#include "ini/ini_read.h"
+#include "unity.h"
+
+#include <string.h>
+
+void setUp(void) {}
+
+void tearDown(void) {}
+
+static int my_ini_handler(char *section, char *key, char *value, void *data_ptr) {
+  //TODO: Add some asserts here.
+  return INI_OK;
+}
+
+static void test_ini_read() {
+  char *filepath = "test_ini_input.ini";
+  int status = ini_read(filepath, my_ini_handler, NULL);
+  TEST_ASSERT_MESSAGE(status == INI_OK, "Failed to load INI file.");
+}
+
+int main(void) {
+  UNITY_BEGIN();
+
+  RUN_TEST(test_ini_read);
+
+  return UNITY_END();
+}

--- a/tests/test_ini_read.c
+++ b/tests/test_ini_read.c
@@ -71,6 +71,22 @@ static void test_ini_parse_int() {
   ival = ini_parse_int("42", &status);
   TEST_ASSERT_MESSAGE(status == INI_OK, "Conversion to int failed.");
   TEST_ASSERT_INT_WITHIN(0, 42, ival);
+ 
+  // Attempting to convert non-number should fail.
+  ival = ini_parse_int("text", &status);
+  TEST_ASSERT(status == INI_FAIL);
+
+  // Attempting to convert a float should fail.
+  ival = ini_parse_int("1.23", &status);
+  TEST_ASSERT(status == INI_FAIL);
+
+  // Attempting to convert a string with trailing text should fail.
+  ival = ini_parse_int("1234 trailing text", &status);
+  TEST_ASSERT(status == INI_FAIL);
+
+  // Attempting to convert a string with leading and trailing whitespace should work.
+  ival = ini_parse_int("   1234    ", &status);
+  TEST_ASSERT(status == INI_OK);
 }
 
 static void test_ini_parse_double() {
@@ -84,6 +100,23 @@ static void test_ini_parse_double() {
   dval = ini_parse_double("-567.8", &status);
   TEST_ASSERT_MESSAGE(status == INI_OK, "Conversion to double failed.");
   TEST_ASSERT_DOUBLE_WITHIN(0.05, -567.8, dval);
+
+  // Attempting to convert an integer should work.
+  dval = ini_parse_double("14159", &status);
+  TEST_ASSERT_MESSAGE(status == INI_OK, "Conversion to double failed.");
+  TEST_ASSERT_DOUBLE_WITHIN(0.5, 14159, dval);
+
+  // Attempting to convert non-number should fail.
+  dval = ini_parse_double("text", &status);
+  TEST_ASSERT(status == INI_FAIL);
+
+  // Attempting to convert a string with trailing text should fail.
+  dval = ini_parse_double("12.34 trailing text", &status);
+  TEST_ASSERT(status == INI_FAIL);
+
+  // Attempting to convert a string with leading and trailing whitespace should work.
+  dval = ini_parse_double("  1.234   ", &status);
+  TEST_ASSERT(status == INI_OK);
 }
 
 static void test_ini_parse_double_list() {
@@ -93,6 +126,29 @@ static void test_ini_parse_double_list() {
   TEST_ASSERT_MESSAGE(status == INI_OK, "Conversion to double list failed.");
   TEST_ASSERT(array != NULL);
   TEST_ASSERT(length == 6);
+  free(array);
+
+  // a 'list' with a single value with should work.
+  length = 0;
+  array = ini_parse_double_list("999", &length, &status);
+  TEST_ASSERT_MESSAGE(status == INI_OK, "Conversion to double list failed.");
+  TEST_ASSERT(array != NULL);
+  TEST_ASSERT(length == 1);
+  free(array);
+
+  // an empty list should fail.
+  length = 0;
+  array = ini_parse_double_list("", &length, &status);
+  TEST_ASSERT(status == INI_FAIL);
+  TEST_ASSERT(array == NULL);
+  TEST_ASSERT(length == 0);
+
+  // a list where one or more item is not a double should fail.
+  length = 0;
+  array = ini_parse_double_list("1,2,text,10x,5", &length, &status);
+  TEST_ASSERT(status == INI_FAIL);
+  TEST_ASSERT(array == NULL);
+  TEST_ASSERT(length == 0);
 }
 
 int main(void) {

--- a/tests/test_ini_read.c
+++ b/tests/test_ini_read.c
@@ -41,6 +41,8 @@ static int my_ini_handler(char *section, char *key, char *value, void *data_ptr)
       TEST_ASSERT_EQUAL_STRING("234.5", value);
     } else if (!strcmp(key, "attribute")) {
       TEST_ASSERT_EQUAL_STRING("42", value);
+    } else if (!strcmp(key, "list_variable")) {
+      TEST_ASSERT_EQUAL_STRING("1, 1, 2, 3, 5, 8", value);
     } else if (!strcmp(key, "#disabled")) {
       TEST_FAIL_MESSAGE("Trying to set disabled key.");
     } else if (!strcmp(key, ";disabled")) {


### PR DESCRIPTION
under the [sealock] header, the user can specify the flow_profile key with one or more comma separated values. These values do not have to be normalized, this will be done internally by libzsf.

In this change I added support for reading a line of comma separated double values from the zsf_config ini file.
I also refactored and improved code, so usability and consistency was been improved.

Unit testing has been added for all the ini_read functions. 